### PR TITLE
Add support for Engines that use ES6 default export

### DIFF
--- a/src/smith.js
+++ b/src/smith.js
@@ -33,7 +33,9 @@ function Spritesmith(params) {
     // Attempt to load the engine
     try {
       Engine = require(engineName);
-      if(typeof Engine !== 'function') Engine = Engine.default;
+      if (typeof Engine !== 'function') {
+        Engine = Engine.default;
+      }
     } catch (err) {
       console.error('Attempted to load spritesmith engine "' + engineName + '" but could not.');
       console.error('Please verify you have installed its dependencies. Documentation should be available at ');

--- a/src/smith.js
+++ b/src/smith.js
@@ -33,6 +33,7 @@ function Spritesmith(params) {
     // Attempt to load the engine
     try {
       Engine = require(engineName);
+      if(typeof Engine !== 'function') Engine = Engine.default;
     } catch (err) {
       console.error('Attempted to load spritesmith engine "' + engineName + '" but could not.');
       console.error('Please verify you have installed its dependencies. Documentation should be available at ');


### PR DESCRIPTION
With ES6 modules, we would `export default class Engine` instead of `module.exports = Engine`.  This change allows spritesmith to load engines in both styles.  It's totally backwards compatible.